### PR TITLE
Implement the remote debugging feature

### DIFF
--- a/front-end-node/NodeInspectorOverrides.js
+++ b/front-end-node/NodeInspectorOverrides.js
@@ -91,6 +91,10 @@ WebInspector.NodeInspectorOverrides.prototype = {
     var params = Runtime._queryParamsObject;
     params['port'] = params['port'] || '5858';
     params['ws'] = params['ws'] || (location.host + location.pathname);
+    if (params['host']) {
+        params['ws'] += /\?/.test(params['ws']) ? '&' : '?';
+        params['ws'] += 'host=' + params['host'];
+    }
     params['ws'] += /\?/.test(params['ws']) ? '&' : '?';
     params['ws'] += 'port=' + params['port'];
   },

--- a/lib/DebuggerClient.js
+++ b/lib/DebuggerClient.js
@@ -21,8 +21,9 @@ function createFailingConnection(reason) {
  * @constructor
  * @param {number} debuggerPort
  */
-function DebuggerClient(debuggerPort) {
+function DebuggerClient(debuggerHost, debuggerPort) {
   this._conn = createFailingConnection('node-inspector server was restarted');
+  this._host = debuggerHost;
   this._port = debuggerPort;
 
   this.target = null;
@@ -52,7 +53,7 @@ Object.defineProperties(DebuggerClient.prototype, {
 });
 
 DebuggerClient.prototype.connect = function() {
-  this._conn = DebugConnection.attachDebugger(this._port);
+  this._conn = DebugConnection.attachDebugger(this._host, this._port);
 
   this._conn
     .on('connect', this._onConnectionOpen.bind(this))

--- a/lib/DebuggerClient.js
+++ b/lib/DebuggerClient.js
@@ -1,6 +1,7 @@
 var extend = require('util')._extend;
 var EventEmitter = require('events').EventEmitter,
   inherits = require('util').inherits,
+  os = require('os'),
   DebugConnection = require('./debugger.js');
 
 function createFailingConnection(reason) {
@@ -49,6 +50,20 @@ Object.defineProperties(DebuggerClient.prototype, {
     get: function() {
       return this._conn.connected && !!this.target;
     }
+  },
+
+  isHostMachine: {
+      get: function() {
+          var addresses = ['localhost', '0.0.0.0'];
+          var ifaces = os.networkInterfaces();
+          for (name in ifaces) {
+              var ifaceAddresses = ifaces[name].map( function(iface) {
+                  return iface['address']
+              });
+              addresses = addresses.concat(ifaceAddresses);
+          }
+          return (addresses.indexOf(this._host) >= 0);
+      }
   }
 });
 

--- a/lib/InjectorClient.js
+++ b/lib/InjectorClient.js
@@ -48,6 +48,12 @@ InjectorClient.prototype.inject = function(cb) {
 
   var _water = [];
 
+  if (this.needsInject && !this._debuggerClient.isHostMachine) {
+    console.log('node process is running on the remote machine.');
+    console.log('In this case, --inject option is ignored.');
+    this._noInject = true;
+  }
+
   if (this.needsInject) {
     _water.unshift(
       this._getFuncWithNMInScope.bind(this),

--- a/lib/PageAgent.js
+++ b/lib/PageAgent.js
@@ -60,6 +60,7 @@ extend(PageAgent.prototype, {
   _doGetResourceTree: function(params, done) {
     var cwd = this._debuggerClient.target.cwd;
     var filename = this._debuggerClient.target.filename;
+    return done(); //ByJunil for test
 
     async.waterfall(
       [

--- a/lib/PageAgent.js
+++ b/lib/PageAgent.js
@@ -60,8 +60,9 @@ extend(PageAgent.prototype, {
   _doGetResourceTree: function(params, done) {
     var cwd = this._debuggerClient.target.cwd;
     var filename = this._debuggerClient.target.filename;
-    return done(); //ByJunil for test
-
+    if (!this._debuggerClient.isHostMachine) {
+        return done();
+    }
     async.waterfall(
       [
         this._resolveMainAppScript.bind(this, cwd, filename),

--- a/lib/config.js
+++ b/lib/config.js
@@ -57,6 +57,16 @@ var definitions = {
     _isNodeDebugOption: true,
     default: 5858
   },
+  'debug-host': {
+    type: 'string',
+    description: 'Host to run Node/V8 debugger.',
+    usage: {
+      '--debug-host 127.0.0.1': '',
+      '--debug-host www.example.com': ''
+    },
+    _isNodeInspectorOption: true,
+    default: '127.0.0.1'
+  },
   'save-live-edit': {
     type: 'boolean',
     description: 'Save live edit changes to disk (update the edited files).',

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -57,8 +57,9 @@ function protocolJson(req, res) {
 }
 
 function handleWebSocketConnection(socket) {
-  var debugPort = this._getDebuggerPort(socket.upgradeReq.url);
-  this._createSession(debugPort, socket);
+  var debugPort = this._getDebuggerPort(socket.upgradeReq.url),
+      debugHost = this._getDebuggerHost(socket.upgradeReq.url);
+  this._createSession(debugHost, debugPort, socket);
 }
 
 function handleServerListening() {
@@ -144,14 +145,19 @@ DebugServer.prototype._getDebuggerPort = function(url) {
   return parseInt((/[\?\&]port=(\d+)/.exec(url) || [null, this._config.debugPort])[1], 10);
 };
 
+DebugServer.prototype._getDebuggerHost = function(url) {
+  return (/[\?\&]host=(\d+)/.exec(url) || [null, this._config.debugHost])[1];
+};
+
 DebugServer.prototype._getUrlFromReq = function(req) {
   var urlParts = req.headers.host.split(':'),
-      debugPort = this._getDebuggerPort(req.url);
+      debugPort = this._getDebuggerPort(req.url),
+      debugHost = this._getDebuggerHost(req.url);
   return buildInspectorUrl(urlParts[0], urlParts[1], debugPort, this._isHTTPS);
 };
 
-DebugServer.prototype._createSession = function(debugPort, wsConnection) {
-  return new Session(this._config, debugPort, wsConnection);
+DebugServer.prototype._createSession = function(debugHost, debugPort, wsConnection) {
+  return new Session(this._config, debugHost, debugPort, wsConnection);
 };
 
 DebugServer.prototype.close = function() {

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -146,7 +146,7 @@ DebugServer.prototype._getDebuggerPort = function(url) {
 };
 
 DebugServer.prototype._getDebuggerHost = function(url) {
-  return (/[\?\&]host=(\d+)/.exec(url) || [null, this._config.debugHost])[1];
+  return (/[\?\&]host=([0-9.]+)/.exec(url) || [null, this._config.debugHost])[1];
 };
 
 DebugServer.prototype._getUrlFromReq = function(req) {

--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -8,7 +8,8 @@ var Net = require('net'),
 /**
 * @param {Number} port
 */
-function Debugger(port){
+function Debugger(host, port){
+  this._host = host;
   this._port = port;
   this._connected = false;
   this._connection = null;
@@ -33,7 +34,7 @@ Object.defineProperties(Debugger.prototype, {
 });
 
 Debugger.prototype._setupConnection = function() {
-  var connection = Net.createConnection(this._port),
+  var connection = Net.createConnection(this._port, this._host),
       protocol = new Protocol();
 
   protocol.onResponse = this._processResponse.bind(this);
@@ -151,6 +152,6 @@ Debugger.prototype.close = function() {
 * @param {Number} port
 * @type {Debugger}
 */
-module.exports.attachDebugger = function(port) {
-  return new Debugger(port);
+module.exports.attachDebugger = function(host, port) {
+  return new Debugger(host, port);
 };

--- a/lib/session.js
+++ b/lib/session.js
@@ -9,8 +9,8 @@ var EventEmitter = require('events').EventEmitter,
     HeapProfilerClient = require('./HeapProfilerClient').HeapProfilerClient,
     InjectorClient = require('./InjectorClient').InjectorClient;
 
-function Session(config, debuggerPort, wsConnection) {
-  this.debuggerClient = new DebuggerClient(debuggerPort);
+function Session(config, debuggerHost, debuggerPort, wsConnection) {
+  this.debuggerClient = new DebuggerClient(debuggerHost, debuggerPort);
   this.frontendClient = new FrontendClient(wsConnection);
   this.injectorClient = new InjectorClient(config, this);
   this.consoleClient = new ConsoleClient(config, this);

--- a/lib/session.js
+++ b/lib/session.js
@@ -10,8 +10,8 @@ var EventEmitter = require('events').EventEmitter,
     InjectorClient = require('./InjectorClient').InjectorClient;
 
 function Session(config, debuggerHost, debuggerPort, wsConnection) {
-  this.debuggerClient = new DebuggerClient(debuggerHost, debuggerPort);
-  this.frontendClient = new FrontendClient(wsConnection);
+  this.debuggerClient = new DebuggerClient(debuggerHost, debuggerPort); //node-inspector <-> debuggable node process
+  this.frontendClient = new FrontendClient(wsConnection); //frontend <-> node-inspector websocket server
   this.injectorClient = new InjectorClient(config, this);
   this.consoleClient = new ConsoleClient(config, this);
   this.heapProfilerClient = new HeapProfilerClient(config, this);


### PR DESCRIPTION
You can use the remote debugging feature using one of two options.
## options 1

run `node-inspector` with `--debug-host` option.

```
$ ./bin/inspector.js --debug-host 192.168.123.12
then
open the url.
 e.g.) http://127.0.0.1:8080/debug?port=5858
```
## option 2

specify the remote machine address as a host parameter in the url

```
$ ./bin/inspector.js --debug-host 192.168.123.12
then
specify the remote machine address as host parameter in the url
 e.g.) http://127.0.0.1:8080/debug?host=192.168.123.12&port=5858
```
## :Notes:
- In this case, you cannot use the injection feature as node(v8) process
  is running on the remote machine.
- I added a condition not to enter the code cannot be runnable in this case.
  See. 'lig/PageAgent.js#_doGetResourceTree()'.
  In the function, it just return cb() without performing the intended jobs.
