### PR TITLE
[0.7.x] Change node-inspector to support the remote debugging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Command line options:
 ```
 --debug-brk, -b         Break on the first line (`node --debug-brk`) [default: true]
 --web-port, -p, --port  Node Inspector port (`node-inspector --web-port={port}`)
+--debug-port, -d        Node/V8 debugger ip address (`node-inspector --debug-host={port}`)
 --debug-port, -d        Node/V8 debugger port (`node --debug={port}`)
 --cli, -c               CLI mode, do not open browser.
 --version, -v           Print Node Inspector's version.
@@ -291,6 +292,7 @@ Use dashed option names in RC files. Sample config file:
 {
   "web-port": 8088,
   "web-host": null,
+  "debug-host": "127.0.0.1",
   "debug-port": 5858,
   "save-live-edit": true,
   "no-preload": true,
@@ -305,6 +307,7 @@ List of predefined options:
 --help               |             | Print information about options
 --web-port           |    8080     | Port to host the inspector
 --web-host           |  127.0.0.1  | Host to listen on
+--debug-port         |  127.0.0.1  | Host where the debugging app runs on
 --debug-port         |    5858     | Port to connect to the debugging app
 --save-live-edit     |    false    | Save live edit changes to disk
                      |             |   (update the edited files)

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Command line options:
 ```
 --debug-brk, -b         Break on the first line (`node --debug-brk`) [default: true]
 --web-port, -p, --port  Node Inspector port (`node-inspector --web-port={port}`)
---debug-port, -d        Node/V8 debugger ip address (`node-inspector --debug-host={port}`)
+--debug-host            Host where the debugged app is running (`node-inspector --debug-host={port}`)
 --debug-port, -d        Node/V8 debugger port (`node --debug={port}`)
 --cli, -c               CLI mode, do not open browser.
 --version, -v           Print Node Inspector's version.
@@ -292,8 +292,8 @@ Use dashed option names in RC files. Sample config file:
 {
   "web-port": 8088,
   "web-host": null,
-  "debug-host": "127.0.0.1",
   "debug-port": 5858,
+  "debug-host": null,
   "save-live-edit": true,
   "no-preload": true,
   "hidden": [],
@@ -307,8 +307,8 @@ List of predefined options:
 --help               |             | Print information about options
 --web-port           |    8080     | Port to host the inspector
 --web-host           |  127.0.0.1  | Host to listen on
---debug-port         |  127.0.0.1  | Host where the debugging app runs on
 --debug-port         |    5858     | Port to connect to the debugging app
+--debug-host         |  127.0.0.1  | Host where the debugged app is running
 --save-live-edit     |    false    | Save live edit changes to disk
                      |             |   (update the edited files)
 --preload            |    true     | Preload *.js files. You can disable this option

--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ Command line options:
 ```
 --debug-brk, -b         Break on the first line (`node --debug-brk`) [default: true]
 --web-port, -p, --port  Node Inspector port (`node-inspector --web-port={port}`)
---debug-host            Host where the debugged app is running (`node-inspector --debug-host={port}`)
 --debug-port, -d        Node/V8 debugger port (`node --debug={port}`)
 --cli, -c               CLI mode, do not open browser.
 --version, -v           Print Node Inspector's version.

--- a/bin/node-debug.js
+++ b/bin/node-debug.js
@@ -27,10 +27,6 @@ var argvOptions = {
     type: 'number',
     description: 'Node/V8 debugger port (`node --debug={port}`)'
   },
-  'debug-host': {
-    type: 'string',
-    description: 'Host where the debugged app is running (`node-inspector --debug-host={url}`)'
-  },
   nodejs: {
     type: 'string',
     description: 'Pass NodeJS options to debugged process (`node --option={value}`)\n' +
@@ -155,10 +151,8 @@ function parseArgs(argv) {
   }
 
   var inspectorPort = options['web-port'] || 8080;
-  var debugHost = options['debug-host'] || '';
   var inspectorArgs = extractPassThroughArgs(options, argvOptions)
-    .concat(['--web-port=' + inspectorPort])
-    .concat(['--debug-host=' + debugHost]);
+    .concat(['--web-port=' + inspectorPort]);
 
   return {
     printScript: printScript,
@@ -171,7 +165,6 @@ function parseArgs(argv) {
     },
     inspector: {
       port: inspectorPort,
-      debugHost: debugHost,
       args: inspectorArgs
     }
   };
@@ -304,9 +297,7 @@ function openBrowserAndPrintInfo() {
   var url = inspector.buildInspectorUrl(
     'localhost',
     config.inspector.port,
-    config.subproc.debugPort,
-    null,
-    config.inspector.debugHost
+    config.subproc.debugPort
   );
 
   if (!config.options.cli) {

--- a/bin/node-debug.js
+++ b/bin/node-debug.js
@@ -27,6 +27,10 @@ var argvOptions = {
     type: 'number',
     description: 'Node/V8 debugger port (`node --debug={port}`)'
   },
+  'debug-host': {
+    type: 'string',
+    description: 'Host where the debugged app is running (`node-inspector --debug-host={url}`)'
+  },
   nodejs: {
     type: 'string',
     description: 'Pass NodeJS options to debugged process (`node --option={value}`)\n' +
@@ -151,8 +155,10 @@ function parseArgs(argv) {
   }
 
   var inspectorPort = options['web-port'] || 8080;
+  var debugHost = options['debug-host'] || '';
   var inspectorArgs = extractPassThroughArgs(options, argvOptions)
-    .concat(['--web-port=' + inspectorPort]);
+    .concat(['--web-port=' + inspectorPort])
+    .concat(['--debug-host=' + debugHost]);
 
   return {
     printScript: printScript,
@@ -165,6 +171,7 @@ function parseArgs(argv) {
     },
     inspector: {
       port: inspectorPort,
+      debugHost: debugHost,
       args: inspectorArgs
     }
   };
@@ -204,7 +211,7 @@ function extractPassThroughArgs(options, argvOptions) {
     if (optionsToSkip[key]) return;
     //Filter camelKey options created by yargs
     if (/[A-Z]/.test(key)) return;
-    
+
     var value = options[key];
     if (value === undefined) return;
     if (value === true) {
@@ -287,7 +294,7 @@ function checkWinCmdFiles(script) {
   if (process.platform == 'win32' && path.extname(script).toLowerCase() == '.cmd') {
     var cmdContent = '' + fs.readFileSync(script);
     var link = (WIN_CMD_LINK_MATCHER.exec(cmdContent) || [])[1];
-    
+
     if (link) script = path.resolve(path.dirname(script), link);
   }
   return script;
@@ -297,7 +304,9 @@ function openBrowserAndPrintInfo() {
   var url = inspector.buildInspectorUrl(
     'localhost',
     config.inspector.port,
-    config.subproc.debugPort
+    config.subproc.debugPort,
+    null,
+    config.inspector.debugHost
   );
 
   if (!config.options.cli) {

--- a/front-end/DOMExtension.js
+++ b/front-end/DOMExtension.js
@@ -562,7 +562,7 @@ Node.prototype.traversePreviousNode = function(stayWithin)
 
 function isEnterKey(event) {
     // Check if in IME.
-    return event.keyCode !== 229 && event.keyIdentifier === "Enter";
+    return event.keyCode !== 229 && (event.keyIdentifier === "Enter" || event.key === "Enter");
 }
 
 function consumeEvent(e)
@@ -610,4 +610,3 @@ NonLeakingMutationObserver.prototype = {
         delete this._observer;
     }
 }
-

--- a/index.js
+++ b/index.js
@@ -9,13 +9,16 @@ exports.buildInspectorUrl = buildInspectorUrl;
  * @param {number} inspectorPort as configured via --web-port
  * @param {number} debugPort as configured via --debug in the debugged app
  */
-function buildInspectorUrl(inspectorHost, inspectorPort, debugPort, fileToShow) {
+function buildInspectorUrl(inspectorHost, inspectorPort, debugHost, debugPort, fileToShow) {
   var parts = {
     protocol: 'http',
     hostname: inspectorHost || '127.0.0.1',
     port: inspectorPort,
     pathname: '/debug',
-    search: '?port=' + debugPort
+    query: {
+        host: debugHost,
+        port: debugPort
+    }
   };
 
   return url.format(parts);

--- a/index.js
+++ b/index.js
@@ -9,17 +9,21 @@ exports.buildInspectorUrl = buildInspectorUrl;
  * @param {number} inspectorPort as configured via --web-port
  * @param {number} debugPort as configured via --debug in the debugged app
  */
-function buildInspectorUrl(inspectorHost, inspectorPort, debugHost, debugPort, fileToShow) {
+function buildInspectorUrl(inspectorHost, inspectorPort, debugPort, fileToShow) {
   var parts = {
     protocol: 'http',
     hostname: inspectorHost || '127.0.0.1',
     port: inspectorPort,
     pathname: '/debug',
     query: {
-        host: debugHost,
         port: debugPort
     }
   };
+  // For backward compatibility, we'd like to keep arguments.
+  // But if arguments.length > 4, we take fifth argument as a debugHost.
+  if (buildInspectorUrl.arguments.length > 4 && buildInspectorUrl.arguments[4]) {
+      parts.query['host'] = buildInspectorUrl.arguments[4];
+  }
 
   return url.format(parts);
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ exports.buildInspectorUrl = buildInspectorUrl;
  * @param {number} inspectorPort as configured via --web-port
  * @param {number} debugPort as configured via --debug in the debugged app
  */
-function buildInspectorUrl(inspectorHost, inspectorPort, debugPort, fileToShow) {
+function buildInspectorUrl(inspectorHost, inspectorPort, debugPort, fileToShow, debugHost) {
   var parts = {
     protocol: 'http',
     hostname: inspectorHost || '127.0.0.1',
@@ -19,10 +19,9 @@ function buildInspectorUrl(inspectorHost, inspectorPort, debugPort, fileToShow) 
         port: debugPort
     }
   };
-  // For backward compatibility, we'd like to keep arguments.
-  // But if arguments.length > 4, we take fifth argument as a debugHost.
-  if (buildInspectorUrl.arguments.length > 4 && buildInspectorUrl.arguments[4]) {
-      parts.query['host'] = buildInspectorUrl.arguments[4];
+
+  if (debugHost) {
+      parts.query['host'] = debugHost;
   }
 
   return url.format(parts);

--- a/lib/DebuggerClient.js
+++ b/lib/DebuggerClient.js
@@ -1,6 +1,7 @@
 var extend = require('util')._extend;
 var EventEmitter = require('events').EventEmitter,
   inherits = require('util').inherits,
+  os = require('os'),
   DebugConnection = require('./debugger.js');
 
 function createFailingConnection(reason) {
@@ -21,8 +22,9 @@ function createFailingConnection(reason) {
  * @constructor
  * @param {number} debuggerPort
  */
-function DebuggerClient(debuggerPort) {
+function DebuggerClient(debuggerHost, debuggerPort) {
   this._conn = createFailingConnection('node-inspector server was restarted');
+  this._host = debuggerHost;
   this._port = debuggerPort;
 }
 
@@ -40,11 +42,25 @@ Object.defineProperties(DebuggerClient.prototype, {
     get: function() {
       return this._conn.connected;
     }
+  },
+
+  isHostMachine: {
+    get: function() {
+      var addresses = ['localhost', '0.0.0.0'];
+      var ifaces = os.networkInterfaces();
+      for (var name in ifaces) {
+          var ifaceAddresses = ifaces[name].map(function(iface) {
+              return iface['address'];
+          });
+          addresses = addresses.concat(ifaceAddresses);
+      }
+      return (addresses.indexOf(this._host) >= 0);
+    }
   }
 });
 
 DebuggerClient.prototype.connect = function() {
-  this._conn = DebugConnection.attachDebugger(this._port);
+  this._conn = DebugConnection.attachDebugger(this._host, this._port);
 
   this._conn.
     on('connect', this._onConnectionOpen.bind(this)).

--- a/lib/DebuggerClient.js
+++ b/lib/DebuggerClient.js
@@ -21,8 +21,9 @@ function createFailingConnection(reason) {
 /**
  * @constructor
  * @param {number} debuggerPort
+ * @param {string} debuggerHost
  */
-function DebuggerClient(debuggerHost, debuggerPort) {
+function DebuggerClient(debuggerPort, debuggerHost) {
   this._conn = createFailingConnection('node-inspector server was restarted');
   this._host = debuggerHost;
   this._port = debuggerPort;
@@ -60,7 +61,7 @@ Object.defineProperties(DebuggerClient.prototype, {
 });
 
 DebuggerClient.prototype.connect = function() {
-  this._conn = DebugConnection.attachDebugger(this._host, this._port);
+  this._conn = DebugConnection.attachDebugger(this._port, this._host);
 
   this._conn.
     on('connect', this._onConnectionOpen.bind(this)).

--- a/lib/PageAgent.js
+++ b/lib/PageAgent.js
@@ -46,6 +46,12 @@ extend(PageAgent.prototype, {
       this.emit('resource-tree');
     }.bind(this);
 
+    if (!this._debuggerClient.isHostMachine) {
+        return this._debuggerClient.once(
+          'connect',
+          cb
+        );
+    }
     if (this._debuggerClient.isConnected) {
       this._doGetResourceTree(params, cb);
     } else {

--- a/lib/PageAgent.js
+++ b/lib/PageAgent.js
@@ -46,7 +46,7 @@ extend(PageAgent.prototype, {
       this.emit('resource-tree');
     }.bind(this);
 
-    //skip building a list of source files from the filesystem
+    // skip building a list of source files from the filesystem
     // because we are running on a different machine
     if (!this._debuggerClient.isHostMachine) {
         return this._debuggerClient.once(

--- a/lib/PageAgent.js
+++ b/lib/PageAgent.js
@@ -46,6 +46,8 @@ extend(PageAgent.prototype, {
       this.emit('resource-tree');
     }.bind(this);
 
+    //skip building a list of source files from the filesystem
+    // because we are running on a different machine
     if (!this._debuggerClient.isHostMachine) {
         return this._debuggerClient.once(
           'connect',

--- a/lib/config.js
+++ b/lib/config.js
@@ -82,10 +82,9 @@ var definitions = {
     defaultValue: 5858
   },
   'debug-host': {
-    desc: 'Host to run Node/V8 debugger.',
-    type: 'string',
+    desc: 'Host where the debugged app is running',
     convert: conversions.checkIfNull,
-    defaultValue: '127.0.0.1'
+    defaultValue: ''
   },
   'save-live-edit': {
     desc: 'Save live edit changes to disk (update the edited files)',

--- a/lib/config.js
+++ b/lib/config.js
@@ -81,6 +81,12 @@ var definitions = {
     convert: conversions.stringToInt,
     defaultValue: 5858
   },
+  'debug-host': {
+    desc: 'Host to run Node/V8 debugger.',
+    type: 'string',
+    convert: conversions.checkIfNull,
+    defaultValue: '127.0.0.1'
+  },
   'save-live-edit': {
     desc: 'Save live edit changes to disk (update the edited files)',
     convert: conversions.stringToBoolean,

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -1,4 +1,6 @@
 var http = require('http'),
+    querystring = require('querystring'),
+    url = require('url'),
     EventEmitter = require('events').EventEmitter,
     inherits = require('util').inherits,
     extend = require('util')._extend,
@@ -63,12 +65,14 @@ DebugServer.prototype._getDebuggerPort = function(url) {
   return parseInt((/\?port=(\d+)/.exec(url) || [null, this._config.debugPort])[1], 10);
 };
 
-DebugServer.prototype._getDebuggerHost = function(url) {
-  return (/[\?\&]host=([0-9.a-zA-Z:/]+)/.exec(url) || [null, this._config.debugHost])[1];
+DebugServer.prototype._getDebuggerHost = function(urlString) {
+  var parsedUrl = url.parse(urlString);
+  var query = querystring.parse(parsedUrl.query);
+  return query.host;
 };
 
 DebugServer.prototype._createSession = function(debugPort, debugHost) {
-  return Session.create(debugPort, debugHost, this._config);
+  return Session.create(debugPort, this._config, debugHost);
 };
 
 DebugServer.prototype.close = function() {

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -18,8 +18,9 @@ function overridesAction(req, res) {
 }
 
 function handleWebSocketConnection(socket) {
-  var debugPort = this._getDebuggerPort(socket.upgradeReq.url);
-  this._createSession(debugPort).join(socket);
+  var debugPort = this._getDebuggerPort(socket.upgradeReq.url),
+      debugHost = this._getDebuggerHost(socket.upgradeReq.url);
+  this._createSession(debugHost, debugPort).join(socket);
 }
 
 function handleServerListening() {
@@ -62,8 +63,12 @@ DebugServer.prototype._getDebuggerPort = function(url) {
   return parseInt((/\?port=(\d+)/.exec(url) || [null, this._config.debugPort])[1], 10);
 };
 
-DebugServer.prototype._createSession = function(debugPort) {
-  return Session.create(debugPort, this._config);
+DebugServer.prototype._getDebuggerHost = function(url) {
+  return (/[\?\&]host=([0-9.]+)/.exec(url) || [null, this._config.debugHost])[1];
+};
+
+DebugServer.prototype._createSession = function(debugHost, debugPort) {
+  return Session.create(debugHost, debugPort, this._config);
 };
 
 DebugServer.prototype.close = function() {
@@ -76,7 +81,7 @@ DebugServer.prototype.close = function() {
 DebugServer.prototype.address = function() {
   var address = this._httpServer.address();
   var config = this._config;
-  address.url = buildUrl(config.webHost, address.port, config.debugPort);
+  address.url = buildUrl(config.webHost, address.port, config.debugHost, config.debugPort);
   return address;
 };
 

--- a/lib/debug-server.js
+++ b/lib/debug-server.js
@@ -20,7 +20,7 @@ function overridesAction(req, res) {
 function handleWebSocketConnection(socket) {
   var debugPort = this._getDebuggerPort(socket.upgradeReq.url),
       debugHost = this._getDebuggerHost(socket.upgradeReq.url);
-  this._createSession(debugHost, debugPort).join(socket);
+  this._createSession(debugPort, debugHost).join(socket);
 }
 
 function handleServerListening() {
@@ -64,11 +64,11 @@ DebugServer.prototype._getDebuggerPort = function(url) {
 };
 
 DebugServer.prototype._getDebuggerHost = function(url) {
-  return (/[\?\&]host=([0-9.]+)/.exec(url) || [null, this._config.debugHost])[1];
+  return (/[\?\&]host=([0-9.a-zA-Z:/]+)/.exec(url) || [null, this._config.debugHost])[1];
 };
 
-DebugServer.prototype._createSession = function(debugHost, debugPort) {
-  return Session.create(debugHost, debugPort, this._config);
+DebugServer.prototype._createSession = function(debugPort, debugHost) {
+  return Session.create(debugPort, debugHost, this._config);
 };
 
 DebugServer.prototype.close = function() {
@@ -81,7 +81,7 @@ DebugServer.prototype.close = function() {
 DebugServer.prototype.address = function() {
   var address = this._httpServer.address();
   var config = this._config;
-  address.url = buildUrl(config.webHost, address.port, config.debugHost, config.debugPort);
+  address.url = buildUrl(config.webHost, address.port, config.debugPort, null, config.debugHost);
   return address;
 };
 

--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -8,12 +8,13 @@ var Net = require('net'),
 /**
 * @param {Number} port
 */
-function Debugger(port){
+function Debugger(host, port){
+  this._host = host;
   this._port = port;
   this._connected = false;
   this._connection = null;
   this._lastError = null;
-  
+
   this._setupConnection();
 }
 
@@ -22,7 +23,7 @@ inherits(Debugger, EventEmitter);
 Object.defineProperties(Debugger.prototype, {
   /** @type {boolean} */
   isRunning: { writable: true, value: true },
-  
+
   /** @type {boolean} */
   connected: {
     get: function() {
@@ -32,9 +33,9 @@ Object.defineProperties(Debugger.prototype, {
 });
 
 Debugger.prototype._setupConnection = function() {
-  var connection = Net.createConnection(this._port),
+  var connection = Net.createConnection(this._port, this._host),
       protocol = new Protocol();
-  
+
   protocol.onResponse = this._processResponse.bind(this);
 
   connection
@@ -44,7 +45,7 @@ Debugger.prototype._setupConnection = function() {
     .on('end', this.close.bind(this))
     .on('close', this._onConnectionClose.bind(this))
     .setEncoding('utf8');
-    
+
   this._connection = connection;
 };
 
@@ -74,7 +75,7 @@ Debugger.prototype._onConnectionError = function(err) {
 
 Debugger.prototype._onConnectionClose = function(hadError) {
   this.emit('close', hadError ? this._lastError : 'Debugged process exited.');
-  
+
   this._port = null;
   this._connected = false;
   this._connection = null;
@@ -146,6 +147,6 @@ Debugger.prototype.close = function() {
 * @param {Number} port
 * @type {Debugger}
 */
-module.exports.attachDebugger = function(port) {
-  return new Debugger(port);
+module.exports.attachDebugger = function(host, port) {
+  return new Debugger(host, port);
 };

--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -7,10 +7,11 @@ var Net = require('net'),
 
 /**
 * @param {Number} port
+* @param {string} host
 */
-function Debugger(host, port){
-  this._host = host;
+function Debugger(port, host){
   this._port = port;
+  this._host = host;
   this._connected = false;
   this._connection = null;
   this._lastError = null;
@@ -147,6 +148,6 @@ Debugger.prototype.close = function() {
 * @param {Number} port
 * @type {Debugger}
 */
-module.exports.attachDebugger = function(host, port) {
-  return new Debugger(host, port);
+module.exports.attachDebugger = function(port, host) {
+  return new Debugger(port, host);
 };

--- a/lib/session.js
+++ b/lib/session.js
@@ -10,7 +10,7 @@ var events = require('events'),
 ///////////////////////////////////////////////////////////
 // exports
 
-exports.create = function(debuggerHost, debuggerPort, config) {
+exports.create = function(debuggerPort, debuggerHost, config) {
   var sessionInstance,
       scriptManager,
       frontendCommandHandler,
@@ -44,7 +44,7 @@ exports.create = function(debuggerHost, debuggerPort, config) {
     join: {
       value: function(wsConnection) {
         frontendClient = new FrontendClient(wsConnection);
-        debuggerClient = new DebuggerClient(debuggerHost, debuggerPort);
+        debuggerClient = new DebuggerClient(debuggerPort, debuggerHost);
 
         scriptManager = new ScriptManager(
           config.isScriptHidden,

--- a/lib/session.js
+++ b/lib/session.js
@@ -10,7 +10,7 @@ var events = require('events'),
 ///////////////////////////////////////////////////////////
 // exports
 
-exports.create = function(debuggerPort, debuggerHost, config) {
+exports.create = function(debuggerPort, config, debuggerHost) {
   var sessionInstance,
       scriptManager,
       frontendCommandHandler,

--- a/lib/session.js
+++ b/lib/session.js
@@ -10,7 +10,7 @@ var events = require('events'),
 ///////////////////////////////////////////////////////////
 // exports
 
-exports.create = function(debuggerPort, config) {
+exports.create = function(debuggerHost, debuggerPort, config) {
   var sessionInstance,
       scriptManager,
       frontendCommandHandler,
@@ -44,7 +44,7 @@ exports.create = function(debuggerPort, config) {
     join: {
       value: function(wsConnection) {
         frontendClient = new FrontendClient(wsConnection);
-        debuggerClient = new DebuggerClient(debuggerPort);
+        debuggerClient = new DebuggerClient(debuggerHost, debuggerPort);
 
         scriptManager = new ScriptManager(
           config.isScriptHidden,


### PR DESCRIPTION
### :Detailed Notes:
node-inspector had to run on the same machine
with the debuggable nodejs process.
This patch supports a remote debugging for the debuggable nodejs
running on the difference machine via ip address.

### :Example:
./bin/inspector.js --debug-host='192.168.0.12' --debug-port=5858
or put the host address and port in the config.json and run inspector.js
or can change the value of the host argument in the url.
  ex) http://127.0.0.1:8080/debug?host=192.168.0.12&port=5858

### :Etc:
- This patch aims to merge into node-inspector v0.7.x branch.
- As KeyboardEvent.keyIdentifier has been removed
  from thre recent browsers including chrome 54 rev,
  front-end should use KeyboardEvent.key instead.